### PR TITLE
Use alpine based ScaResolver

### DIFF
--- a/CxScaResolver/bitbucket-pipelines.yml
+++ b/CxScaResolver/bitbucket-pipelines.yml
@@ -8,7 +8,7 @@ pipelines:
   default:
     - step:
         script:
-          - wget https://sca-downloads.s3.amazonaws.com/cli/latest/ScaResolver-linux64.tar.gz
+          - wget https://sca-downloads.s3.amazonaws.com/cli/latest/ScaResolver-musl64.tar.gz
           - tar -xzvf ScaResolver-linux64.tar.gz
           - rm -rf ScaResolver-linux64.tar.gz
           - >-


### PR DESCRIPTION
The ast-cli docker image is based on alpine linux. Hence, the you have to wget the musl version of Scaresolver (alpine version). Otherwise, it will not work.