### PR TITLE
Concatenated Scan names on gitlabCI

### DIFF
--- a/GitlabCICD/v2/CheckmarxCLI.gitlab-ci.yml
+++ b/GitlabCICD/v2/CheckmarxCLI.gitlab-ci.yml
@@ -14,6 +14,7 @@ variables:
     CX_CLIENT_ID: ${CX_CLIENT_ID}
     CX_CLIENT_SECRET: ${CX_CLIENT_SECRET}
     GITLAB_TOKEN: ${GITLAB_TOKEN}
+    GITLAB_PATH: "" # Should be the number of the PATH that you want to concatenate with the repository name
     CX_ADDITIONAL_PARAMS: ""
     CX_FILE_FILTERS: ""
     CHECKMARX_DOCKER_IMAGE: "ast-cli"
@@ -29,10 +30,11 @@ checkmarx-scan:
     - if: '$SECURITY_DASHBOARD != "true" && $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH'
   script:
     - eval "args=(${CX_ADDITIONAL_PARAMS})"
+    - export GIT_GROUP=$(echo $CI_PROJECT_NAMESPACE | cut -d'/' -${GITLAB_PATH})
     - >-
       /app/bin/cx
       scan create
-      --project-name ${CX_PROJECT_NAME}
+      --project-name $GIT_GROUP-${CX_PROJECT_NAME}
       --file-source '.'
       --scan-info-format 'json'
       --branch ${CX_BRANCH_NAME}
@@ -50,10 +52,11 @@ mr-checkmarx-scan:
   script:
     - eval "args=(${CX_ADDITIONAL_PARAMS})"
     - output_file=./output.log
+    - export GIT_GROUP=$(echo $CI_PROJECT_NAMESPACE | cut -d'/' -${GITLAB_POSITION})
     - >-
       /app/bin/cx
       scan create
-      --project-name ${CX_PROJECT_NAME}
+      --project-name $GIT_GROUP-${CX_PROJECT_NAME}
       --file-source '.'
       --scan-info-format 'json'
       --branch ${CX_BRANCH_NAME}
@@ -79,10 +82,11 @@ mr-checkmarx-scan-security-dashboard:
   script:
     - eval "args=(${CX_ADDITIONAL_PARAMS})"
     - output_file=./output.log
+    - export GIT_GROUP=$(echo $CI_PROJECT_NAMESPACE | cut -d'/' -${GITLAB_POSITION})
     - >-
       /app/bin/cx
       scan create
-      --project-name ${CX_PROJECT_NAME}
+      --project-name $GIT_GROUP-${CX_PROJECT_NAME}
       --file-source '.'
       --scan-info-format 'json'
       --branch ${CX_BRANCH_NAME}
@@ -112,10 +116,11 @@ checkmarx-scan-security-dashboard:
     entrypoint: ['']
   script:
     - eval "args=(${CX_ADDITIONAL_PARAMS})"
+    - export GIT_GROUP=$(echo $CI_PROJECT_NAMESPACE | cut -d'/' -${GITLAB_POSITION})
     - >-
       /app/bin/cx
       scan create
-      --project-name ${CX_PROJECT_NAME}
+      --project-name $GIT_GROUP-${CX_PROJECT_NAME}
       --file-source '.'
       --scan-info-format 'json'
       --branch ${CX_BRANCH_NAME}


### PR DESCRIPTION
**Problem Explanation:**

The current implementation of the integration between Checkmarx Scan via ast/cli Docker image inside a gitlab CICD pipeline does not take consideration about projects that are called the same, but they are located in differents "PATH" on Gitlab. ex. Organizations might have use cases like this:

      gitlab.com/group/subgroup1/subgroup2/subgroup3/repo-abc
      gitlab.com/group/subgroupA/subgroupB/subgroupC/repo-abc

As you might notice, the complete PATH of the repo is quite a bit different in terms of naming, but the repository name is the same, causing potential overwrite of the scan results on the Checkmarx web interface, crashing the metrics.

**Solution proposal**

As a posible solution we have implemented a manipulation of the flag "--project-name", concatenating the value of the Gitlab predefined variable "CI_PROJECT_NAMESPACE", and defining a new variable on the CI file wich is a number of the position that you want to choose to be correlated. ex:

New var:

     GITLAB_PATH: "" #It should be the number of the PATH that you want to concatenate with the repository name

Now inside the "script" sentence, we add new "export" definition to manipulate the new value via a new variable

     script:
       - eval "args=(${CX_ADDITIONAL_PARAMS})"
       - export GIT_GROUP=$(echo $CI_PROJECT_NAMESPACE | cut -d'/' -${GITLAB_PATH})
       - >-
         /app/bin/cx

This allow you to select the position number 1, 2, 3....n, as you wish, where tha value will became "/subgroup2" for example.

So this gives you the change to call the "--project-name" flag with a custom name and be able to have unique scan results for each repository in gitlab CICD pipelines.

    --project-name $GIT_GROUP-${CX_PROJECT_NAME}

Retrieving a resulta like this:

   "ProjectName":"subgroup2-repo-abc","Status":"Running","CreatedAt"

Hope this works and you find any use for it, otherwise feel free to close the PR.

Best, 