### PR TITLE
Resolve AST-116522 by replacing read with readarray for robust argument parsing

### DIFF
--- a/GitlabCICD/v1/CheckmarxCLI.gitlab-ci.yml
+++ b/GitlabCICD/v1/CheckmarxCLI.gitlab-ci.yml
@@ -23,7 +23,7 @@ checkmarx-scan:
     name: checkmarx/${CHECKMARX_DOCKER_IMAGE}
     entrypoint: ['']
   script:
-    - read -r -a args <<< "$CX_ADDITIONAL_PARAMS"
+    - readarray -t args < <(xargs -n1 <<< "$CX_ADDITIONAL_PARAMS")
     - >-
       /app/bin/cx
       scan create

--- a/GitlabCICD/v2/CheckmarxCLI.gitlab-ci.yml
+++ b/GitlabCICD/v2/CheckmarxCLI.gitlab-ci.yml
@@ -49,7 +49,7 @@ mr-checkmarx-scan:
     name: checkmarx/${CHECKMARX_DOCKER_IMAGE}
     entrypoint: ['']
   script:
-    - read -r -a args <<< "$CX_ADDITIONAL_PARAMS"
+    - readarray -t args < <(xargs -n1 <<< "$CX_ADDITIONAL_PARAMS")
     - output_file=./output.log
     - >
       if [ -n "$CX_LINK_SERVER_HOST" ]; then
@@ -89,7 +89,7 @@ mr-checkmarx-scan-security-dashboard:
     name: checkmarx/${CHECKMARX_DOCKER_IMAGE}
     entrypoint: ['']
   script:
-    - read -r -a args <<< "$CX_ADDITIONAL_PARAMS"
+    - readarray -t args < <(xargs -n1 <<< "$CX_ADDITIONAL_PARAMS")
     - output_file=./output.log
     - >
       if [ -n "$CX_LINK_SERVER_HOST" ]; then
@@ -134,7 +134,7 @@ checkmarx-scan-security-dashboard:
     name: checkmarx/${CHECKMARX_DOCKER_IMAGE}
     entrypoint: ['']
   script:
-    - read -r -a args <<< "$CX_ADDITIONAL_PARAMS"
+    - readarray -t args < <(xargs -n1 <<< "$CX_ADDITIONAL_PARAMS")
     - >-
       /app/bin/cx
       scan create


### PR DESCRIPTION
Fix an issue in GitLab CI/CD where scans did not start when using flags that include spaces in their values. ([AST-116522](https://checkmarx.atlassian.net/browse/AST-116522))

[AST-116522]: https://checkmarx.atlassian.net/browse/AST-116522?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ