### PR TITLE
Update GitHub examples to use scan_params instead of additional_params

### DIFF
--- a/Github/ast-private-registry-scan.yml
+++ b/Github/ast-private-registry-scan.yml
@@ -16,7 +16,7 @@ name: Checkmarx Scan
 # Controls when the workflow will run
 on:
   push:
-    branches: [ "master" ]
+    branches: ["master"]
   workflow_dispatch:
 
 permissions:
@@ -37,7 +37,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
 
     steps:
-      - name :  Checkout repository
+      - name: Checkout repository
         uses: actions/checkout@v4
 
       - name: Checkmarx One scan
@@ -51,13 +51,13 @@ jobs:
           USERNAME_MYCOMPANY_JFROG_IO: ${{ secrets.JFROG_USERNAME }}
           PASSWORD_MYCOMPANY_JFROG_IO: ${{ secrets.JFROG_ACCESS_TOKEN }}
         with:
-          base_uri: https://eu.ast.checkmarx.net  # This should be replaced by your base uri for Checkmarx One
+          base_uri: https://eu.ast.checkmarx.net # This should be replaced by your base uri for Checkmarx One
           cx_client_id: ${{ secrets.CX_CLIENT_ID }} # This should be created within your Checkmarx One account : https://checkmarx.com/resource/documents/en/34965-118315-authentication-for-checkmarx-one-cli.html#UUID-a4e31a96-1f36-6293-e95a-97b4b9189060_UUID-4123a2ff-32d0-2287-8dd2-3c36947f675e
           cx_client_secret: ${{ secrets.CX_CLIENT_SECRET }} # This should be created within your Checkmarx One account : https://checkmarx.com/resource/documents/en/34965-118315-authentication-for-checkmarx-one-cli.html#UUID-a4e31a96-1f36-6293-e95a-97b4b9189060_UUID-4123a2ff-32d0-2287-8dd2-3c36947f675e
           cx_tenant: ${{ secrets.CX_TENANT }} # This should be replaced by your tenant for Checkmarx One
-          additional_params: --scan-types container-security --containers-local-resolution
+          scan_params: --scan-types container-security --containers-local-resolution
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@v3
         with:
-           # Path to SARIF file relative to the root of the repository
+          # Path to SARIF file relative to the root of the repository
           sarif_file: cx_result.sarif

--- a/Github/sarif-output.yml
+++ b/Github/sarif-output.yml
@@ -29,7 +29,7 @@ jobs:
           cx_client_id: ${{ secrets.CX_CLIENT_ID }}
           cx_client_secret: ${{ secrets.CX_CLIENT_SECRET }}
           cx_tenant: ${{ secrets.CX_TENANT }} # This should be replaced by users' tenant name
-          additional_params: --report-format sarif --output-path .
+          scan_params: --report-format sarif --output-path .
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@v2
         with:

--- a/Sonar/ci-maven.yml
+++ b/Sonar/ci-maven.yml
@@ -6,7 +6,6 @@ on:
 
 jobs:
   scan:
-
     runs-on: ubuntu-latest
     if: ${{ true }}
 
@@ -38,15 +37,15 @@ jobs:
       - name: Checkmarx AST CLI Action
         uses: checkmarx/ast-github-action@main
         with:
-            project_name: <your_project_name>
-            base_uri: <AST Base URI>
-            cx_tenant: ${{ secrets.CX_TENANT }}
-            cx_client_id: ${{ secrets.CX_CLIENT_ID }}
-            cx_client_secret: ${{ secrets.CX_CLIENT_SECRET }}
-            additional_params: --report-format sonar
+          project_name: <your_project_name>
+          base_uri: <AST Base URI>
+          cx_tenant: ${{ secrets.CX_TENANT }}
+          cx_client_id: ${{ secrets.CX_CLIENT_ID }}
+          cx_client_secret: ${{ secrets.CX_CLIENT_SECRET }}
+          scan_params: --report-format sonar
 
       - name: Sonar analyze
-        run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=<sonar_project_key> -Dsonar.organization=<sonar_organization> -Dsonar.externalIssuesReportPaths=./cx_result_sonar.json 
+        run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=<sonar_project_key> -Dsonar.organization=<sonar_organization> -Dsonar.externalIssuesReportPaths=./cx_result_sonar.json
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ github.token }}

--- a/Sonar/ci.yml
+++ b/Sonar/ci.yml
@@ -17,8 +17,8 @@ jobs:
           cx_tenant: ${{ secrets.TENANT }}
           cx_client_id: ${{ secrets.CLIENT_ID }}
           cx_client_secret: ${{ secrets.SECRET }}
-          additional_params: --report-format sonar
-      - name: Sonar CLI Action 
+          scan_params: --report-format sonar
+      - name: Sonar CLI Action
         uses: sonarsource/sonarqube-scan-action@master
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
While updating my GitHub action, I saw the informational message in my action logs: 
```
ADDITIONAL_PARAMS is deprecated. Please use SCAN_PARAMS instead.
```

It looks like `scan_params` replaces `additional_params` for a majority of the examples shown, based on the PR [here](https://github.com/Checkmarx/ast-github-action/pull/284) with very limited documentation supporting it [here](https://docs.checkmarx.com/en/34965-68704-configuring-a-github-action-with-a-checkmarx-one-workflow.html#UUID-7f08dec0-e35b-bf16-294f-9d49480def1f)

In that PR, @cx-anurag-dalke mentioned to update the samples, but that never got done. This PR should correct that, at least for GitHub examples.
